### PR TITLE
移除會造成問題的 console log

### DIFF
--- a/src/main/java/us/dontcareabout/gwt/client/GFEP.java
+++ b/src/main/java/us/dontcareabout/gwt/client/GFEP.java
@@ -115,8 +115,6 @@ public abstract class GFEP implements EntryPoint {
 			if (!f.support) { notSupport.add(f); }
 		}
 
-		Console.inspect(notSupport);
-		Console.log(notSupport.isEmpty());
 		return notSupport.isEmpty();
 	}
 


### PR DESCRIPTION
這兩行會造成 IE8 在顯示頁面時，因為 console undefined 造成錯誤而無法顯示。