### PR TITLE
java.nio.file.Paths 的替代品

### DIFF
--- a/src/main/java/us/dontcareabout/java/common/Paths.java
+++ b/src/main/java/us/dontcareabout/java/common/Paths.java
@@ -1,0 +1,64 @@
+package us.dontcareabout.java.common;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 以 fluent style 取代 {@link java.nio.file.Paths}。
+ */
+public class Paths {
+	private ArrayList<String> children = new ArrayList<>();
+	private boolean existFolder;
+
+	public Paths(String root) {
+		children.add(root);
+	}
+
+	public Paths append(String child) {
+		children.add(child);
+		return this;
+	}
+
+	public Paths append(String... childArray) {
+		children.addAll(Arrays.asList(childArray));
+		return this;
+	}
+
+	public Paths append(List<String> childList) {
+		children.addAll(childList);
+		return this;
+	}
+
+	/**
+	 * 在 {@link #toFile()} / {@link #toPath()} 時會檢查該目錄是否存在，
+	 * 如果不存在會作 {@link File#mkdirs()}
+	 */
+	public Paths existFolder() {
+		existFolder = true;
+		return this;
+	}
+
+	public File toFile() {
+		if (children.size() == 0) { return new File(""); }
+
+		StringBuilder sb = new StringBuilder(children.get(0));
+
+		for (int i = 1; i < children.size(); i++) {
+			sb.append(File.separator);
+			sb.append(children.get(i));
+		}
+
+		File result = new File(sb.toString());
+
+		if (existFolder && !result.exists()) { result.mkdirs(); }
+
+		return result;
+	}
+
+	public Path toPath() {
+		return toFile().toPath();
+	}
+}


### PR DESCRIPTION
主要是試圖解決產生 `File` instance 的問題。

例如要作 code generator，通常會需要下列資訊湊出 `File`：

* classpath 根目錄
* package 名稱
* class 檔名

這時候傳統 `File(String, String)` 要自己先湊出第二個參數的字串，用 `java.nio.file.Paths.get()` 也沒有比較快樂（甚至更慘），因為他的參數是 `String[]`。

現在這個替代品，理論上讓 caller 只要：

```Java
File file = new Paths(root).append(packageName.split("\\.")).append(fileName).toFile();
```

應該是有方便很多。

剩下來的問題就是：

* JDK / guava 裡頭有沒有（我沒找到的）類似替代品
* 名字名字名字...... :scream: 
* 該不該出現在 GF 裡頭

請詰譙 [擺茶點]